### PR TITLE
Maybe an improvement

### DIFF
--- a/extension/fuzzySearch.js
+++ b/extension/fuzzySearch.js
@@ -1,12 +1,43 @@
-document.body.addEventListener("keydown", appendFuzzyToTarget);
-console.log("FuzzySearch active");
+'use strict';
 
-function appendFuzzyToTarget(e) {
-    if(e.target.classList.contains("multiselect__input"))
-    {
-        if(!e.target.value.startsWith("~"))
-        {
-            e.target.value = "~" + e.target.value;
-        }
+const afterDOMLoaded = () => {
+  // var to store all input fields
+  let inputFieldNodeList = 'undefined';
+
+  const getInputFields = () => document.querySelectorAll('.multiselect__input');
+  const addFuzzyToNode = (e) => {
+    if (!e.target.value.startsWith('~')) {
+      e.target.value = '~' + e.target.value;
+      // remove the event listener when the user wrote something into the field to prevent input lag
+      e.target.removeEventListener('keydown', addFuzzyToNode);
     }
+  };
+
+  const wait = (ms) => {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  };
+
+  // fetch all input fields and only attach listeners when input field is empty
+  // already attached listeners will be overwritten
+  const restoreListeners = async () => {
+    inputFieldNodeList = getInputFields();
+    inputFieldNodeList.forEach((selectInput) => {
+      if (selectInput.value == '')
+        selectInput.addEventListener('keydown', addFuzzyToNode, false);
+    });
+
+    // wait a second before overwriting new listeners
+    await wait(1000);
+
+    restoreListeners();
+  };
+
+  // start here
+  restoreListeners();
+};
+
+if (document.readyState === 'loading') {
+  document.addEventListener('DOMContentLoaded', afterDOMLoaded, false);
+} else {
+  afterDOMLoaded();
 }

--- a/extension/manifest.json
+++ b/extension/manifest.json
@@ -5,12 +5,9 @@
   "version": "0.2.0",
   "content_scripts": [
     {
-      "matches": [
-        "*://*.pathofexile.com/trade*"
-      ],
-      "js": [
-        "fuzzySearch.js"
-      ]
+      "matches": ["*://*.pathofexile.com/trade*"],
+      "js": ["fuzzySearch.js"],
+      "run_at": "document_start"
     }
   ]
 }


### PR DESCRIPTION
It removes event listeners when input fields are already filled with text and add them again as soon the field is empty.
Executes the script when DOM is loaded.

Sources of when to execute scripts: 
- https://developer.chrome.com/docs/extensions/mv2/content_scripts/#run_time
- https://stackoverflow.com/a/43245774/10192487